### PR TITLE
picota.py agora funciona via command line

### DIFF
--- a/portaltransparencia/despesas-execucao/picota.py
+++ b/portaltransparencia/despesas-execucao/picota.py
@@ -1,5 +1,5 @@
 #!/usr/local/bin/python3
-# -*- coding: iso-8859-15 -*-
+
 
 import sys
 import re
@@ -7,11 +7,12 @@ import pandas as pd
 
 
 def grafico(source):
-    arquivo = pd.read_csv(source, delimiter=";")
-    colunas = list(filter(
-        lambda c: re.search(r'código', c, re.I) is None, list(arquivo.columns)
-    ))
-    arquivo[colunas].to_csv('graficos/' + source, index=False)
+
+    arquivo = pd.read_csv(source, delimiter=";", low_memory=False)
+    colunas = filter(
+        lambda c: re.search(r'^código', c, re.I) is None, arquivo.columns
+    )
+    arquivo[list(colunas)].to_csv('graficos/' + source, index=False)
 
 
 source = sys.argv[1]


### PR DESCRIPTION
Remove configuração ISO que, aparentemente, estava causando problemas. Parece que os csvs estão no formato UTF-8

¯\_(ツ)_/¯